### PR TITLE
fix missing psutil dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,11 @@ setup(
 	install_requires=[
 		'evalcache==1.10.0',
 		'pyservoce==1.9.4',
+		'psutil',
 		'numpy',
 		'pillow',
 		'inotify',
 		'PyQt5',
-		'zencad-cli',
+		'zencad-cli'
 	],
 )


### PR DESCRIPTION
I have an error after installing zencad through `pipx`:
```
> pipx install --include-deps zencad
> zencad
Traceback (most recent call last):
  File "/home/ont/.local/bin/zencad", line 4, in <module>
    import zencad
  File "/home/ont/.local/pipx/venvs/zencad/lib/python3.7/site-packages/zencad/__init__.py", line 12, in <module>
    from zencad.visual import screen
  File "/home/ont/.local/pipx/venvs/zencad/lib/python3.7/site-packages/zencad/visual.py", line 2, in <module>
    import zencad.shower
  File "/home/ont/.local/pipx/venvs/zencad/lib/python3.7/site-packages/zencad/shower.py", line 14, in <module>
    import psutil
ModuleNotFoundError: No module named 'psutil'
```

Probably this patch will fix this error.