### PR TITLE
fix inotify for vim editor (again)

### DIFF
--- a/zencad/gui/inotifier.py
+++ b/zencad/gui/inotifier.py
@@ -28,9 +28,12 @@ class InotifyThread(QThread):
 		while 1:
 			self.lock.acquire()
 
-			if (os.stat(self.path).st_mtime != self.last_mtime):
-				self.last_mtime = os.stat(self.path).st_mtime
-				self.changed.emit()
+			try:
+				if (os.stat(self.path).st_mtime != self.last_mtime):
+					self.last_mtime = os.stat(self.path).st_mtime
+					self.changed.emit()
+			except FileNotFoundError:
+				pass
 
 			self.lock.release()
 			time.sleep(0.0001)


### PR DESCRIPTION
This commit fix race condition between while-loop and vim editor which tries to replace source file during writing to disk. It turns out that there may be a case when there is no file on the disk.